### PR TITLE
Zebrunner reporting configured

### DIFF
--- a/Config.properties
+++ b/Config.properties
@@ -7,5 +7,5 @@ resolution=1024x768
 
 
 #Lambdatest Credentails
-LambdaTest_UserName=<YOUR LAMBDATEST USERNAME>
-LambdaTest_AppKey=<YOUR LAMBDATEST APPKEY>
+LambdaTest_UserName=
+LambdaTest_AppKey=

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,22 @@
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
-			<version>6.14.3</version>
-			<!-- <scope>compile</scope> -->
+			<version>7.3.0</version>
+			 <scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<version>1.10.18</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.zebrunner</groupId>
+			<artifactId>agent-testng</artifactId>
+			<version>1.4.0</version>
+			<scope>test</scope>
 		</dependency>
 
 
@@ -70,6 +84,32 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.1.2</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>initialize</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>com.zebrunner</groupId>
+							<artifactId>agent-core</artifactId>
+							<version>RELEASE</version>
+							<outputDirectory>${project.build.directory}/agent</outputDirectory>
+							<destFileName>zebrunner-core-agent.jar</destFileName>
+						</artifactItem>
+					</artifactItems>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
@@ -91,6 +131,7 @@
 					<suiteXmlFiles>
 						<suiteXmlFile>testng.xml</suiteXmlFile>
 					</suiteXmlFiles>
+					<argLine>-javaagent:${project.build.directory}/agent/zebrunner-core-agent.jar</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
 			<version>7.3.0</version>
-			 <scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,22 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Logging dependencies -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.30</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>1.2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.21.0</version>
+				<version>3.0.0-M4</version>
 				<configuration>
 					<suiteXmlFiles>
 						<suiteXmlFile>testng.xml</suiteXmlFile>

--- a/src/main/java/stepDefinitions/ToDoStepDefinition.java
+++ b/src/main/java/stepDefinitions/ToDoStepDefinition.java
@@ -1,20 +1,23 @@
 package stepDefinitions;
 
-import java.net.URL;
-
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import java.net.URL;
 
 public class ToDoStepDefinition {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ToDoStepDefinition.class);
 
 	WebDriver driver;
 	public static String status = "failed";
@@ -42,6 +45,7 @@ public class ToDoStepDefinition {
 		capability.setCapability("video", true);
 		capability.setCapability("console", true);
 		capability.setCapability("visual", true);
+		capability.setCapability("provider", "lambdatest");
 
 		String gridURL = "https://" + username + ":" + accesskey + "@hub.lambdatest.com/wd/hub";
 		driver = new RemoteWebDriver(new URL(gridURL), capability);
@@ -52,12 +56,14 @@ public class ToDoStepDefinition {
 	@When("^select First Item$")
 	public void select_first_item() {
 		driver.findElement(By.name("li1")).click();
+		LOGGER.info("Selected first item");
 	}
 
 
 	@Then("^select second item$")
 	public void select_second_item() {
 		driver.findElement(By.name("li2")).click();
+		LOGGER.info("Selected second item");
 	}
 
 	@Then("^add new item$")
@@ -65,6 +71,7 @@ public class ToDoStepDefinition {
 		driver.findElement(By.id("sampletodotext")).clear();
 		driver.findElement(By.id("sampletodotext")).sendKeys("Yey, Let's add it to list");
 		driver.findElement(By.id("addbutton")).click();
+		LOGGER.info("Adding new item to the list");
 	}
 
 	@Then("^verify added item$")
@@ -72,6 +79,7 @@ public class ToDoStepDefinition {
 		String item = driver.findElement(By.xpath("/html/body/div/div/div/ul/li[6]/span")).getText();
 		Assert.assertTrue(item.contains("Yey, Let's add it to list"));
 		status = "passed";
+		LOGGER.info("Making sure, that the item is there");
 	}
 
 	

--- a/src/main/resources/agent.properties
+++ b/src/main/resources/agent.properties
@@ -1,3 +1,0 @@
-reporting.enabled=false
-reporting.server.hostname=
-reporting.access-token=

--- a/src/main/resources/agent.properties
+++ b/src/main/resources/agent.properties
@@ -1,0 +1,3 @@
+reporting.enabled=false
+reporting.server.hostname=
+reporting.access-token=

--- a/src/main/resources/agent.yaml
+++ b/src/main/resources/agent.yaml
@@ -1,0 +1,5 @@
+reporting:
+  enabled: true
+  server:
+    hostname: <server-hostname-goes-here>
+    access-token: <access-token-goes-here>

--- a/src/main/resources/agent.yaml
+++ b/src/main/resources/agent.yaml
@@ -1,5 +1,0 @@
-reporting:
-  enabled: true
-  server:
-    hostname: <server-hostname-goes-here>
-    access-token: <access-token-goes-here>

--- a/src/main/resources/agent.yaml
+++ b/src/main/resources/agent.yaml
@@ -1,0 +1,6 @@
+reporting:
+ enabled: true
+ server:
+  hostname: <change-me>
+  access-token: <change-me>
+

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="ZebrunnerAppender" class="com.zebrunner.agent.core.logging.logback.ReportingAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%t] %-5level - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="ZebrunnerAppender" />
+    </root>
+</configuration>

--- a/testng.xml
+++ b/testng.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="BDD Test Suite" verbose="1" parallel="tests"
 	thread-count="1" configfailurepolicy="continue">
 	<test name="Lambdatest ToDO Sample Test" annotations="JDK"


### PR DESCRIPTION
Configuration steps:

1. TestNG updated to 7.3.0 (6.x is not supported unfortunately)
2. Zebrunner agent dependency added (`pom.xml`)
3. Reporting configuration added (`src/resources/agent.yaml`) - url and token can be found at https://<your-zebrunner-host>/profile
4. Optional: test sessions tracking configured (more info on **docs -> Tracking of web driver sessions**)

Documentation: https://zebrunner.com/documentation/agents/testng